### PR TITLE
use devDependencies for gulp plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# generator-dyno 
+# generator-dyno
 
 > [Yeoman](http://yeoman.io) generator
 
@@ -48,7 +48,13 @@ $ yo dyno
 Once everything is ready, start the local server:
 
 ```
-$ gulp
+$ gulp serve
+```
+
+If you are ready to deploy the code you have written just build the code using:
+
+```
+$ gulp build
 ```
 
 ### Getting To Know Yeoman

--- a/app/templates/_gulpfileCoffee.js
+++ b/app/templates/_gulpfileCoffee.js
@@ -4,7 +4,7 @@ var gulp            = require('gulp'),
     path        = require('path'),
     browserSync = require('browser-sync'),
     reload      = browserSync.reload,
-    sass        = require('gulp-sass'),
+    sass        = require('gulp-sass');
 
 gulp.task('browser-sync', function() {
   browserSync({

--- a/app/templates/_gulpfileCoffee.js
+++ b/app/templates/_gulpfileCoffee.js
@@ -1,10 +1,10 @@
 var gulp            = require('gulp'),
-    // this is an arbitrary object that loads all gulp plugins in package.json. 
+    // this is an arbitrary object that loads all gulp plugins in package.json.
     $           = require("gulp-load-plugins")(),
     path        = require('path'),
     browserSync = require('browser-sync'),
     reload      = browserSync.reload,
-    sass        = require('gulp-sass');
+    sass        = require('gulp-sass'),
 
 gulp.task('browser-sync', function() {
   browserSync({
@@ -15,13 +15,13 @@ gulp.task('browser-sync', function() {
 });
 
 gulp.task('compass', function() {
-    return gulp.src('./src/stylesheets/*.scss')
-        .pipe($.plumber())
-        .pipe($.compass({
-            css: 'dist/stylesheets',
-            sass: 'src/stylesheets'
-        }))
-        .pipe(gulp.dest('dist/stylesheets'));
+  return gulp.src('./src/stylesheets/*.scss')
+    .pipe($.plumber())
+    .pipe($.compass({
+      css: 'dist/stylesheets',
+      sass: 'src/stylesheets'
+    }))
+    .pipe(gulp.dest('dist/stylesheets'));
 });
 
 gulp.task('coffee', function() {
@@ -54,16 +54,13 @@ gulp.task('templates', function() {
     .pipe( gulp.dest('dist/') )
 });
 
-gulp.task('default',['compass','coffee','images','templates','browser-sync'], function () {
-  
+gulp.task('build', ['compass', 'js', 'templates', 'images']);
+
+gulp.task('serve', ['build', 'browser-sync'], function () {
   gulp.watch('src/stylesheets/*.scss',['compass', reload]);
-
-  gulp.watch('src/scripts/*.coffee',['coffee', reload]);
-  
+  gulp.watch('src/scripts/*.js',['js', reload]);
   gulp.watch('src/images/**/*',['images', reload]);
-
   gulp.watch('src/*.jade',['templates', reload]);
-    
 });
 
-
+gulp.task('default', ['serve']);

--- a/app/templates/_gulpfileCoffee.js
+++ b/app/templates/_gulpfileCoffee.js
@@ -39,6 +39,9 @@ gulp.task('coffee', function() {
 
 gulp.task('images', function() {
   return gulp.src('./src/images/*')
+    .pipe($.imagemin({
+      progressive: true
+    }))
     .pipe(gulp.dest('./dist/images'))
 })
 

--- a/app/templates/_gulpfileJavascript.js
+++ b/app/templates/_gulpfileJavascript.js
@@ -1,5 +1,5 @@
 var gulp            = require('gulp'),
-    // this is an arbitrary object that loads all gulp plugins in package.json. 
+    // this is an arbitrary object that loads all gulp plugins in package.json.
     $           = require("gulp-load-plugins")(),
     path        = require('path'),
     browserSync = require('browser-sync'),
@@ -15,13 +15,13 @@ gulp.task('browser-sync', function() {
 });
 
 gulp.task('compass', function() {
-    return gulp.src('./src/stylesheets/*.scss')
-        .pipe($.plumber())
-        .pipe($.compass({
-            css: 'dist/stylesheets',
-            sass: 'src/stylesheets'
-        }))
-        .pipe(gulp.dest('dist/stylesheets'))
+  return gulp.src('./src/stylesheets/*.scss')
+    .pipe($.plumber())
+    .pipe($.compass({
+      css: 'dist/stylesheets',
+      sass: 'src/stylesheets'
+    }))
+    .pipe(gulp.dest('dist/stylesheets'))
 });
 
 gulp.task('js', function() {
@@ -52,16 +52,13 @@ gulp.task('templates', function() {
     .pipe( gulp.dest('dist/') )
 });
 
-gulp.task('default',['compass','js','templates','browser-sync'], function () {
-  
+gulp.task('build', ['compass', 'js', 'templates', 'images']);
+
+gulp.task('serve', ['build', 'browser-sync'], function () {
   gulp.watch('src/stylesheets/*.scss',['compass', reload]);
-
   gulp.watch('src/scripts/*.js',['js', reload]);
-  
   gulp.watch('src/images/**/*',['images', reload]);
-
   gulp.watch('src/*.jade',['templates', reload]);
-    
 });
 
-
+gulp.task('default', ['serve']);

--- a/app/templates/_gulpfileJavascript.js
+++ b/app/templates/_gulpfileJavascript.js
@@ -37,6 +37,9 @@ gulp.task('js', function() {
 
 gulp.task('images', function() {
   return gulp.src('./src/images/*')
+    .pipe($.imagemin({
+      progressive: true
+    }))
     .pipe(gulp.dest('./dist/images'))
 })
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -1,7 +1,7 @@
 {
   "name": "<%= _.slugify(appname) %>",
   "version": "0.0.0",
-  "dependencies": {
+  "devDependencies": {
     "browser-sync": "^1.8.1",
     "browserify": "^3.41.0",
     "coffeeify": "^0.6.0",
@@ -17,6 +17,6 @@
     "gulp-sass": "~0.4.1",
     "gulp-uglify": "~0.1.0",
     "gulp-util": "~2.2.12",
-    "marked": "~0.3.0"  
+    "marked": "~0.3.0"
   }
 }

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -1,6 +1,7 @@
 /*global describe, beforeEach, it */
 'use strict';
 var path = require('path');
+var asset = require('yeoman-generator').assert;
 var helpers = require('yeoman-generator').test;
 
 describe('dyno generator', function () {
@@ -17,20 +18,45 @@ describe('dyno generator', function () {
     }.bind(this));
   });
 
-  it('creates expected files', function (done) {
-    var expected = [
-      // add files you expect to exist here.
-      '.jshintrc',
-      '.editorconfig'
-    ];
+  it('creates files in root', function (done) {
+    assert.file([
+      'gulpfile.js',
+      'package.json',
+      'bower.json',
+      '.bowerrc',
+      '.gitignore',
+      '.editorconfig',
+      '.jshintrc'
+    ]);
+  });
 
-    helpers.mockPrompt(this.app, {
-      'someOption': true
-    });
-    this.app.options['skip-install'] = true;
-    this.app.run({}, function () {
-      helpers.assertFile(expected);
-      done();
-    });
+  it('creates files in /src', function (done) {
+    assets.file([
+      'src/scripts/main.js',
+      'src/scripts/example.js',
+      'src/index.jade',
+      'src/stylesheets/main.scss'
+    ]);
+  });
+
+  it('has right dependencies', function (done) {
+    assert.fileContent([
+      ['package.json': '"browser-sync": "^1.8.1"'],
+      ['package.json': '"browserify": "^3.41.0"'],
+      ['package.json': '"coffeeify": "^0.6.0"'],
+      ['package.json': '"gulp": "^3.5.0"'],
+      ['package.json': '"gulp-browserify": "^0.5.0"'],
+      ['package.json': '"gulp-compass": "~1.1.8"'],
+      ['package.json': '"gulp-concat": "~2.1.7"'],
+      ['package.json': '"gulp-jade": "~0.3.0"'],
+      ['package.json': '"gulp-load-plugins": "^0.5.1"'],
+      ['package.json': '"gulp-minify-css": "^0.3.1"'],
+      ['package.json': '"gulp-plumber": "^0.6.2"'],
+      ['package.json': '"gulp-rename": "^1.2.0"'],
+      ['package.json': '"gulp-sass": "~0.4.1"'],
+      ['package.json': '"gulp-uglify": "~0.1.0"'],
+      ['package.json': '"gulp-util": "~2.2.12"'],
+      ['package.json': '"marked": "~0.3.0"'],
+    ]);
   });
 });

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -1,7 +1,6 @@
 /*global describe, beforeEach, it */
 'use strict';
 var path = require('path');
-var asset = require('yeoman-generator').assert;
 var helpers = require('yeoman-generator').test;
 
 describe('dyno generator', function () {
@@ -18,45 +17,20 @@ describe('dyno generator', function () {
     }.bind(this));
   });
 
-  it('creates files in root', function (done) {
-    assert.file([
-      'gulpfile.js',
-      'package.json',
-      'bower.json',
-      '.bowerrc',
-      '.gitignore',
-      '.editorconfig',
-      '.jshintrc'
-    ]);
-  });
+  it('creates expected files', function (done) {
+    var expected = [
+      // add files you expect to exist here.
+      '.jshintrc',
+      '.editorconfig'
+    ];
 
-  it('creates files in /src', function (done) {
-    assets.file([
-      'src/scripts/main.js',
-      'src/scripts/example.js',
-      'src/index.jade',
-      'src/stylesheets/main.scss'
-    ]);
-  });
-
-  it('has right dependencies', function (done) {
-    assert.fileContent([
-      ['package.json': '"browser-sync": "^1.8.1"'],
-      ['package.json': '"browserify": "^3.41.0"'],
-      ['package.json': '"coffeeify": "^0.6.0"'],
-      ['package.json': '"gulp": "^3.5.0"'],
-      ['package.json': '"gulp-browserify": "^0.5.0"'],
-      ['package.json': '"gulp-compass": "~1.1.8"'],
-      ['package.json': '"gulp-concat": "~2.1.7"'],
-      ['package.json': '"gulp-jade": "~0.3.0"'],
-      ['package.json': '"gulp-load-plugins": "^0.5.1"'],
-      ['package.json': '"gulp-minify-css": "^0.3.1"'],
-      ['package.json': '"gulp-plumber": "^0.6.2"'],
-      ['package.json': '"gulp-rename": "^1.2.0"'],
-      ['package.json': '"gulp-sass": "~0.4.1"'],
-      ['package.json': '"gulp-uglify": "~0.1.0"'],
-      ['package.json': '"gulp-util": "~2.2.12"'],
-      ['package.json': '"marked": "~0.3.0"'],
-    ]);
+    helpers.mockPrompt(this.app, {
+      'someOption': true
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
   });
 });


### PR DESCRIPTION
I had a look at my package.json and wondered why the dependencies are going in `dependencies` and not `devDependencies`.
Changed now.

Edit: Added some more commits. Now with tests and imagemin included.