### PR TITLE
added prompt for installing underscore/jquery by default

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -50,6 +50,14 @@ var DynoGenerator = yeoman.generators.Base.extend({
         { name: 'Pure HTML', value: 'html' },
         { name: 'Jade', value: 'jade' }
       ]
+    },{
+      type: 'checkbox',
+      name: 'bowerComponents',
+      message: 'Would you like to install any of the following?',
+      choices: [
+        { name: 'Underscore', value: 'underscore', checked: true },
+        { name: 'jQuery', value: 'jquery', checked: false }
+      ]
     }, {
       type: 'input',
       name: 'projectVersion',
@@ -68,6 +76,8 @@ var DynoGenerator = yeoman.generators.Base.extend({
       this.projectName = _.slugify(_.camelize(props.projectName, true));
       this.projectVersion = props.projectVersion;
       this.bowerOption = props.bowerOption;
+      this.installUnderscore = props.bowerComponents.indexOf('underscore') !== -1;
+      this.installJquery= props.bowerComponents.indexOf('jquery') !== -1;
       this.templateOption = props.templateOption;
       this.styleOption = props.styleOption;
 

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -1,6 +1,9 @@
 {
   "name": "<%= projectName %>",
   "version": "0.0.0",
-  "dependencies": {},
-  "devDependencies": {}
+  "dependencies": {<% if (installUnderscore) { %>
+    "underscore": "*"<% } %><% if (installJquery) { %>,
+    "jquery": "*"<% } %>
+    },
+  "devDependencies": {  }
 }

--- a/app/templates/_main.js
+++ b/app/templates/_main.js
@@ -1,4 +1,6 @@
 // this is the main file that pulls in all other modules
-var example = require("./example")
-example.welcome()
-
+// you can require() bower components too!
+var example = require("./example");
+example.welcome();<% if (installUnderscore) { %>
+var _ = require("underscore");<% } %><% if (installJquery) { %>
+var $ = require("jquery");<% } %>


### PR DESCRIPTION
@iDuuck can I get a +1 on this pr? It adds a prompt for installing some bower packages by default. 

We may want to add something like `var $ = require("jquery")` to the example.js file as a way to educate people that you can simply require bower components now. 
